### PR TITLE
add outputBasePath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ block scripts
 
 ## Changelog
 
+### 1.1.1
+- added `outputBasePath` option, it makes possible to use absolute routes to static files in jade templates *independently* to the folder structure of views.
+
 ### 1.1.0
 - fixed RegExp issue, now requires you to have a `/` or `.` as first character in your rev replacement (e.g. you need to have relative or absolute paths via `script(src='/foo.js')` as opposed to `script(src='foo.js')`)
 

--- a/index.js
+++ b/index.js
@@ -105,6 +105,10 @@ module.exports = function(options) {
     else {
       var stream = tasks[index];
 
+      if (options.maxListeners) {
+        stream.setMaxListeners(options.maxListeners);
+      }
+
       stream.on('data', writeNewFile);
       stream.on('end', function() {
         stream.removeListener('data', writeNewFile);

--- a/index.js
+++ b/index.js
@@ -29,10 +29,15 @@ module.exports = function(options) {
 
   function createFile(name, content) {
     var filePath = path.join(path.relative(basePath, mainPath), name);
-      var isStatic = name.split('.').pop() === 'js' || name.split('.').pop() === 'css';
+    var isStatic = name.split('.').pop() === 'js' || name.split('.').pop() === 'css';
 
-      if (options.outputRelativePath && isStatic)
-        filePath = options.outputRelativePath + name;
+    if (isStatic) {
+      if (options.outputRelativePath)
+        filePath = path.join(options.outputRelativePath, name);
+
+      if (options.outputBasePath)
+        filePath = path.join(options.outputBasePath, filePath);
+    }
 
     return new gutil.File({
       path: filePath,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jade-usemin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Gulp plugin for running usemin on Jade files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've noticed that output files are depend a lot on file structure of jade files, and i'd like to do not care about relative path too much and use just absolute path to all assets served as static files. This PR makes it possible to use absolute routes to static files in jade templates *independently* to the folder structure of views. When I tried to use just `outputRelativePath: '/'` Jade files have been updated correctly but all resulting JS files went to the wrong folder.

Now if I set
```
outputRelativePath: '/',
outputBasePath: __dirname,
```
this will push all static files into the `__dirname` instead of the system root. 
(Issue has been noticed in docker environment)